### PR TITLE
Remove react references

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -160,8 +160,5 @@ module.exports = {
         extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
     },
-    react: {
-      version: 'detect',
-    },
   },
 };

--- a/README.md
+++ b/README.md
@@ -57,9 +57,7 @@ To enable ESLint in VS Code add the following to your `settings.json`:
   "tslint.enable": false,
   "eslint.validate": [
     "javascript",
-    "javascriptreact",
     "typescript",
-    "typescriptreact"
   ]
 }
 ```


### PR DESCRIPTION
My assumption is that the base package should not have any references to react.

I saw this when working on a non-react project with this configuration giving me a warning about react version.