### PR TITLE
Update linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,10 +33,6 @@ module.exports = {
     // This rule required so many exceptions that it was getting difficult to maintain. So
     // just name things sensibly :)
     '@typescript-eslint/naming-convention': 'off',
-    '@typescript-eslint/explicit-function-return-type': [
-      'error',
-      { allowExpressions: true },
-    ],
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
     // Noop functions are a common pattern we use during testing, so we don't want to enable it.
@@ -79,6 +75,7 @@ module.exports = {
         allowThis: true,
       },
     ],
+    'import/named': 'off', // Redundant when used with Typescript.
     'import/no-extraneous-dependencies': [
       'error',
       {
@@ -123,13 +120,6 @@ module.exports = {
     'no-magic-numbers': [
       'error',
       { ignoreArrayIndexes: true, ignore: ALLOWED_NUMBERS },
-    ],
-
-    // disallow dangling underscores in identifiers
-    // https://eslint.org/docs/rules/no-underscore-dangle
-    'no-underscore-dangle': [
-      'error',
-      { allow: ['__PRELOADED_STATE__', '__APOLLO_STATE__'] },
     ],
 
     // disallow the use of console

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-fishbrain-base",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "ESLint config for Fishbrain TypeScript projects",
   "main": ".eslintrc.js",
   "scripts": {


### PR DESCRIPTION
Three changes here. I'll start with the controversial one.

I think we should disable `@typescript-eslint/explicit-function-return-type`. This rule requires us to write return types on functions, e.g.:

```
function sum(a: number, b: number): number {
  return a + b;
}
```

Removing it will mean we only need to write:

```
function sum(a: number, b: number) {
  return a + b;
}
```

Note that this doesn't prevent us from adding return types as we want - I think they can still be helpful for more complex functions - but I feel like its unneccessary to force this rules as Typescript is really good at inferring types and we're just stepping on its toes.

Removing the `no-underscore-dangle` rules is also an opinionated decision. I don't see the harm in it, and I often want to use leading underscores when I have clashing variable names, e.g.:

```
import { isAdmin } from 'somewhere';

function MyComponent() {
  const _isAdmin = isAdmin();

  if (_isAdmin) {
    // ...do a thing
  }

  return <></>
}
```

The final rule change is turning off `import/named`. This rule just checks that our named imports are actually importing something that exists. Typescript already does it for us though so it's redundant.